### PR TITLE
Improve namespace handling when cloning via https

### DIFF
--- a/src/rfpkg/__init__.py
+++ b/src/rfpkg/__init__.py
@@ -135,7 +135,7 @@ class Commands(pyrpkg.Commands):
             if self.distgit_namespaced:
                 path_parts = [p for p in parts.path.split("/") if p]
                 ns_module_name = "/".join(path_parts[-2:])
-                _ns = path_parts[0]
+                _ns = path_parts[-2]
 
             if ns_module_name.endswith('.git'):
                 ns_module_name = ns_module_name[:-len('.git')]


### PR DESCRIPTION
Users cloning anonymously might want to use https:// instead of git://
for security and/or privacy.

This can be done in one of two ways currently, but the namespace is
wrong in either case.  Either the anongiturl can be changed in
/etc/rpkg/rfpkg.conf:

    $ diff -u /etc/rpkg/rfpkg.conf{.orig,}
    -_- /etc/rpkg/rfpkg.conf.orig	2016-09-14 00:01:53.000000000 -0400
    +_+ /etc/rpkg/rfpkg.conf	2017-01-09 19:09:48.283109356 -0500
    @@ -3,7 +3,7 @@
     lookasidehash = md5
     lookaside_cgi = https://pkgs.rpmfusion.org/repo/pkgs/upload.cgi
     gitbaseurl = ssh://%(user)s@pkgs.rpmfusion.org/%(module)s
    -anongiturl = git://pkgs.rpmfusion.org/%(module)s
    +anongiturl = https://pkgs.rpmfusion.org/git/%(module)s
     branchre = f\d$|f\d\d$|el\d$|master$
     kojiconfig = /etc/koji.conf.d/rpmfusion.conf
     build_client = koji-rpmfusion

Or use git's url.<base>.insteadOf to rewrite git:// urls for rpmfusion:

    $ git config --global url.https://pkgs.rpmfusion.org/git/.insteadOf \
        git://pkgs.rpmfusion.org/

Doing so will cause the namespace to be incorrectly set to git rather
than free or nonfree.  With some debugging added, here is the current
result:

    $ rfpkg sources
    self.push_url = https://pkgs.rpmfusion.org/git/free/rfpkg
    path_parts = [u'git', u'free', u'rfpkg']
    ns_module_name = free/rfpkg
    _ns = git
    Downloading rfpkg-1.25.1.tar.gz
    ######################################################################## 100.0%
    Remove downloaded invalid file ./rfpkg-1.25.1.tar.gz
    Could not execute sources: Server returned status code 404

With the default git:// url, the output is:

    $ rfpkg sources
    self.push_url = git://pkgs.rpmfusion.org/free/rfpkg
    path_parts = [u'free', u'rfpkg']
    ns_module_name = free/rfpkg
    _ns = free
    Downloading rfpkg-1.25.1.tar.gz
    ######################################################################## 100.0%

The module name uses a negative index to get the last 2 parts of the
url.  The namespace should similarly use the second from the last entry
rather than the first.