### PR TITLE
Commands: pass all kwargs to parent

### DIFF
--- a/src/rfpkg/__init__.py
+++ b/src/rfpkg/__init__.py
@@ -29,8 +29,7 @@ class Commands(pyrpkg.Commands):
 
     def __init__(self, path, lookaside, lookasidehash, lookaside_cgi,
                  gitbaseurl, anongiturl, branchre, kojiconfig,
-                 build_client, user=None, dist=None, target=None,
-                 quiet=False, distgit_namespaced=False, realms=None):
+                 build_client, **kwargs):
         """Init the object and some configuration details."""
 
         # We are subclassing to set kojiconfig to none, so that we can
@@ -38,9 +37,7 @@ class Commands(pyrpkg.Commands):
         super(Commands, self).__init__(path, lookaside, lookasidehash,
                                        lookaside_cgi, gitbaseurl, anongiturl,
                                        branchre, kojiconfig, build_client,
-                                       user=user, dist=dist, target=target,
-                                       quiet=quiet,
-                                       distgit_namespaced=distgit_namespaced)
+                                       **kwargs)
 
         # New data
         self.secondary_arch = {


### PR DESCRIPTION
When rpkg adds a new argument to the constructor, this method needs to be updated. But it can simply just pass all the kwargs without looking at them.

The same approach is used in [fedpkg](https://pagure.io/fedpkg/blob/master/f/fedpkg/__init__.py#_27-29).