### PR TITLE
Use profile to load Koji configuration

### DIFF
--- a/src/rfpkg.conf
+++ b/src/rfpkg.conf
@@ -5,7 +5,7 @@ lookaside_cgi = https://pkgs.rpmfusion.org/repo/pkgs/upload.cgi
 gitbaseurl = ssh://%(user)s@pkgs.rpmfusion.org/%(module)s
 anongiturl = git://pkgs.rpmfusion.org/%(module)s
 branchre = f\d$|f\d\d$|el\d$|master$
-kojiconfig = /etc/koji.conf.d/rpmfusion.conf
+kojiprofile = rpmfusion
 build_client = koji-rpmfusion
 clone_config =
   bz.default-tracker bugzilla.rpmfusion.org

--- a/src/rfpkg/__init__.py
+++ b/src/rfpkg/__init__.py
@@ -28,15 +28,13 @@ from pyrpkg.utils import cached_property
 class Commands(pyrpkg.Commands):
 
     def __init__(self, path, lookaside, lookasidehash, lookaside_cgi,
-                 gitbaseurl, anongiturl, branchre, kojiconfig,
+                 gitbaseurl, anongiturl, branchre, kojiprofile,
                  build_client, **kwargs):
         """Init the object and some configuration details."""
 
-        # We are subclassing to set kojiconfig to none, so that we can
-        # make it a property to potentially use a secondary config
         super(Commands, self).__init__(path, lookaside, lookasidehash,
                                        lookaside_cgi, gitbaseurl, anongiturl,
-                                       branchre, kojiconfig, build_client,
+                                       branchre, kojiprofile, build_client,
                                        **kwargs)
 
         # New data
@@ -60,11 +58,11 @@ class Commands(pyrpkg.Commands):
         }
 
         # New properties
-        self._kojiconfig = None
+        self._kojiprofile = None
         self._cert_file = None
         self._ca_cert = None
         # Store this for later
-        self._orig_kojiconfig = kojiconfig
+        self._orig_kojiprofile = kojiprofile
 
         # RPM Fusion default namespace
         self.default_namespace = 'free'
@@ -73,19 +71,19 @@ class Commands(pyrpkg.Commands):
 
     # Add new properties
     @property
-    def kojiconfig(self):
-        """This property ensures the kojiconfig attribute"""
+    def kojiprofile(self):
+        """This property ensures the kojiprofile attribute"""
 
-        if not self._kojiconfig:
-            self.load_kojiconfig()
-        return self._kojiconfig
+        if not self._kojiprofile:
+            self.load_kojiprofile()
+        return self._kojiprofile
 
-    @kojiconfig.setter
-    def kojiconfig(self, value):
-        self._kojiconfig = value
+    @kojiprofile.setter
+    def kojiprofile(self, value):
+        self._kojiprofile = value
 
-    def load_kojiconfig(self):
-        """This loads the kojiconfig attribute
+    def load_kojiprofile(self):
+        """This loads the kojiprofile attribute
 
         This will either use the one passed in via arguments or a
         secondary arch config depending on the package
@@ -96,14 +94,13 @@ class Commands(pyrpkg.Commands):
         try:
             null = self.module_name
         except:
-            self._kojiconfig = self._orig_kojiconfig
+            self._kojiprofile = self._orig_kojiprofile
             return
         for arch in self.secondary_arch.keys():
             if self.module_name in self.secondary_arch[arch]:
-                self._kojiconfig = os.path.expanduser('/etc/koji/rpmfusion-%s-config' %
-                                                      arch)
+                self._kojiprofile = arch
                 return
-        self._kojiconfig = self._orig_kojiconfig
+        self._kojiprofile = self._orig_kojiprofile
 
     @cached_property
     def cert_file(self):

--- a/test/rfpkg-test.conf
+++ b/test/rfpkg-test.conf
@@ -6,5 +6,5 @@ lookaside_cgi = https://pkgs.example.com/repo/pkgs/upload.cgi
 gitbaseurl = ssh://%(user)s@pkgs.example.com/%(module)s
 anongiturl = git://pkgs.example.com/%(module)s
 branchre = f\d$|f\d\d$|el\d$|olpc\d$|master$
-kojiconfig = /etc/koji.conf
+kojiprofile = koji
 build_client = koji


### PR DESCRIPTION
Avoid Deprecation warning: kojiconfig is deprecated. Instead,
kojiprofile should be used.

Refer to similar change in fedpkg, 0d44244 ("Use profile to load Koji
configuration", 2017-04-06).