### PR TITLE
Use --release in place of --dist

### DIFF
--- a/src/_rfpkg
+++ b/src/_rfpkg
@@ -407,6 +407,7 @@ _rfpkg() {
     '(- :)'{-h,--help}'[show help message and exit]' \
     '(-C --config)'{-C,--config}'[specify a config file to use]:config file:_files' \
     '--dist[override the discovered distribution]:distribution' \
+    '--release[override the discovered release]:release' \
     '--user[override the discovered user name]:user' \
     '--path[define the directory to work in (defaults to cwd)]:working direcory:_directories' \
     '(-q)-v[run with verbose debug output]' \

--- a/src/rfpkg.bash
+++ b/src/rfpkg.bash
@@ -33,7 +33,7 @@ _rfpkg()
     # global options
 
     local options="--help -v -q"
-    local options_value="--dist --user --path"
+    local options_value="--dist --release --user --path"
     local commands="build chain-build ci clean clog clone co commit compile \
     container-build diff gimmespec giturl help gitbuildhash import install lint \
     local mockbuild mock-config new new-sources patch prep pull push retire \
@@ -72,7 +72,7 @@ _rfpkg()
         fi
 
         case "$prev" in
-            --dist)
+            --dist|--release)
                 ;;
             --user|-u)
                 ;;

--- a/src/rfpkg/__init__.py
+++ b/src/rfpkg/__init__.py
@@ -162,7 +162,7 @@ class Commands(pyrpkg.Commands):
         self.load_ns_module_name()
 
         # We only match the top level branch name exactly.
-        # Anything else is too dangerous and --dist should be used
+        # Anything else is too dangerous and --release should be used
         # This regex works until after Fedora 99.
         if re.match(r'f\d\d$', self.branch_merge):
             self._distval = self.branch_merge.split('f')[1]
@@ -189,8 +189,8 @@ class Commands(pyrpkg.Commands):
             self._distunset = 'rhel'
         # If we don't match one of the above, punt
         else:
-            raise pyrpkg.rpkgError('Could not find the dist from branch name '
-                                   '%s\nPlease specify with --dist' %
+            raise pyrpkg.rpkgError('Could not find the release/dist from branch name '
+                                   '%s\nPlease specify with --release' %
                                    self.branch_merge)
         self._rpmdefines = ["--define '_sourcedir %s'" % self.path,
                             "--define '_specdir %s'" % self.path,

--- a/test/test_retire.py
+++ b/test/test_retire.py
@@ -74,7 +74,7 @@ class RetireTestCase(unittest.TestCase):
     @mock.patch('pkgdb2client.PkgDB')
     def test_retire_with_namespace(self, PkgDB):
         self._setup_repo('ssh://git@pkgs.example.com/rpms/rfpkg')
-        args = ['rfpkg', '--dist=master', 'retire', 'my reason']
+        args = ['rfpkg', '--release=master', 'retire', 'my reason']
 
         client = self._fake_client(args)
         client.retire()
@@ -88,7 +88,7 @@ class RetireTestCase(unittest.TestCase):
     @mock.patch('pkgdb2client.PkgDB')
     def test_retire_without_namespace(self, PkgDB, read_user_cert):
         self._setup_repo('ssh://git@pkgs.example.com/rfpkg')
-        args = ['rfpkg', '--dist=master', 'retire', 'my reason']
+        args = ['rfpkg', '--release=master', 'retire', 'my reason']
 
         read_user_cert.return_value = 'packager'
 


### PR DESCRIPTION
The --dist option is deprecated in rpkg.

Recommend --release when unable to detect the upstream release/dist.

Add support for --release to the bash and zsh completion scripts.  The
--dist option can be removed after --release has been in place for a few
releases, to aid in the transition.