### PR TITLE
rfpkg.conf: Use 'repo' instead of 'module'

### DIFF
--- a/src/rfpkg.conf
+++ b/src/rfpkg.conf
@@ -2,8 +2,8 @@
 lookaside = http://pkgs.rpmfusion.org/repo/pkgs
 lookasidehash = md5
 lookaside_cgi = https://pkgs.rpmfusion.org/repo/pkgs/upload.cgi
-gitbaseurl = ssh://%(user)s@pkgs.rpmfusion.org/%(module)s
-anongiturl = https://pkgs.rpmfusion.org/git/%(module)s
+gitbaseurl = ssh://%(user)s@pkgs.rpmfusion.org/%(repo)s
+anongiturl = https://pkgs.rpmfusion.org/git/%(repo)s
 branchre = f\d$|f\d\d$|el\d$|master$
 kojiprofile = koji-rpmfusion
 build_client = koji-rpmfusion
@@ -11,6 +11,6 @@ clone_config =
   bz.default-tracker bugzilla.rpmfusion.org
   bz.default-product Fedora
   bz.default-version rawhide
-  bz.default-component %(module)s
-  sendemail.to %(module)s-owner@rpmfusion.org
+  bz.default-component %(repo)s
+  sendemail.to %(repo)s-owner@rpmfusion.org
 distgit_namespaced = True


### PR DESCRIPTION
rfpkg outputs warnings with `%(module)s` in the configs, as it's deprecated:

```console
$ rfpkg clone free/libopenshot-audio
Format argument module is deprecated in gitbaseurl. Please use "repo" instead.
Format argument module is deprecated in anongiturl. Please use "repo" instead.
Format argument module is deprecated in clone config. Please use "ns_repo" instead.
Cloning into 'libopenshot-audio'...
remote: Counting objects: 82, done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 82 (delta 35), reused 40 (delta 17)
Receiving objects: 100% (82/82), 9.55 KiB | 4.77 MiB/s, done.
Resolving deltas: 100% (35/35), done.
```

Use `%(repo)s` instead. (Note: Although the message suggests `ns_repo` as a replacement for `module` in the clone config, that doesn't _seem_ to be a valid token. `/etc/rpkg/fedpkg.conf` on my system uses `%(repo)s` in clone, same as the `...url` configs, so I've done the same here.)