### PR TITLE
Remove the 'update' command

### DIFF
--- a/src/_rfpkg
+++ b/src/_rfpkg
@@ -335,12 +335,6 @@ _rfpkg-retire () {
     ':message'
 }
 
-(( $+functions[_rfpkg-update] )) ||
-_rfpkg-update () {
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[show help message and exit]'
-}
-
 (( $+functions[_rfpkg_commands] )) ||
 _rfpkg_commands () {
   local -a rfpkg_commands
@@ -380,7 +374,6 @@ _rfpkg_commands () {
     verify-files:'locally verify %files section'
     verrel:'print the name-version-release'
     retire:'retire a package'
-    update:'submit last build as an update'
   )
 
   integer ret=1

--- a/src/rfpkg.bash
+++ b/src/rfpkg.bash
@@ -37,7 +37,7 @@ _rfpkg()
     local commands="build chain-build ci clean clog clone co commit compile \
     container-build diff gimmespec giturl help gitbuildhash import install lint \
     local mockbuild mock-config new new-sources patch prep pull push retire \
-    scratch-build sources srpm switch-branch tag unused-patches update upload \
+    scratch-build sources srpm switch-branch tag unused-patches upload \
     verify-files verrel"
 
     # parse main options and get command
@@ -94,7 +94,7 @@ _rfpkg()
     local after= after_more=
 
     case $command in
-        help|gimmespec|gitbuildhash|giturl|lint|new|push|unused-patches|update|verrel)
+        help|gimmespec|gitbuildhash|giturl|lint|new|push|unused-patches|verrel)
             ;;
         build)
             options="--nowait --background --skip-tag --scratch"

--- a/src/rfpkg/__init__.py
+++ b/src/rfpkg/__init__.py
@@ -314,25 +314,6 @@ class Commands(pyrpkg.Commands):
 
         self.commit(message=message)
 
-    def update(self, template='bodhi.template', bugs=[]):
-        """Submit an update to bodhi using the provided template."""
-
-        # build up the bodhi arguments, based on which version of bodhi is
-        # installed
-        bodhi_major_version = _get_bodhi_version()[0]
-        if bodhi_major_version < 2:
-            cmd = ['bodhi', '--new', '--release', self.branch_merge,
-                   '--file', 'bodhi.template', self.nvr, '--username',
-                   self.user]
-        elif bodhi_major_version == 2:
-            cmd = ['bodhi', 'updates', 'new', '--file', 'bodhi.template',
-                   '--user', self.user, self.nvr]
-        else:
-            msg = 'This system has bodhi v{0}, which is unsupported.'
-            msg = msg.format(bodhi_major_version)
-            raise Exception(msg)
-        self._run_command(cmd, shell=True)
-
     def load_kojisession(self, anon=False):
         """Initiate a koji session.
 
@@ -375,18 +356,6 @@ class Commands(pyrpkg.Commands):
                               "https://fedoraproject.org/wiki/Using_the_Koji_build"
                               "_system#Fedora_Account_System_.28FAS2.29_Setup")
                 raise
-
-
-def _get_bodhi_version():
-    """
-    Use bodhi --version to determine the version of the Bodhi CLI that's
-    installed on the system, then return a list of the version components.
-    For example, if bodhi --version returns "2.1.9", this function will return
-    [2, 1, 9].
-    """
-    bodhi = subprocess.Popen(['bodhi', '--version'], stdout=subprocess.PIPE)
-    version = bodhi.communicate()[0].strip()
-    return [int(component) for component in version.split('.')]
 
 
 if __name__ == "__main__":

--- a/src/rfpkg/cli.py
+++ b/src/rfpkg/cli.py
@@ -32,7 +32,10 @@ class rfpkgClient(cliClient):
         """Register the fedora specific targets"""
 
         self.register_retire()
-        self.register_update()
+
+        # Don't register the update command, as rpmfusion does not have a
+        # bodhi instance to send update requests to
+        #self.register_update()
 
     # Target registry goes here
     def register_retire(self):


### PR DESCRIPTION
Per [this post by Sérgio](https://www.mail-archive.com/rpmfusion-developers@lists.rpmfusion.org/msg22739.html), rpmfusion currently has no bodhi instance, so the `rfpkg update` command is not useful. This PR disables it.

(Note: This is the "minimally destructive" version of the change, which simply comments out the call to register the update command, and removes it from the completions. I'm not a big fan of releasing commented-out or unused code even if it might be "eventually" useful (I figure, it's always just a `git diff` away), so my preference would be to actually **remove** all of the code related to update. 

Currently this PR does not remove the code. I already have a local commit that does, which I can push onto this branch if there's agreement that it should be removed for now. Let me know if you'd like me to do that.)