### PR TITLE
Update shebangs to explicitly use python2

### DIFF
--- a/git-changelog
+++ b/git-changelog
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # git-changelog - Output a rpm changelog
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from setuptools import setup
 try:
     from subprocess import getstatusoutput

--- a/src/rfpkg/__main__.py
+++ b/src/rfpkg/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # rfpkg - a script to interact with the RPM Fusion Packaging system
 #
 # Copyright (C) 2011 Red Hat Inc.


### PR DESCRIPTION
A few Python files still had `#!/usr/bin/python` shebangs at the top, and since [the plan][1] for next Fedora release is to upgrade that check from a build-time deprecation warning to a build failure, we should be explicitly calling `/usr/bin/python2` instead.

[1]: https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error