### PR TITLE
--dist removed from bash-completion

### DIFF
--- a/conf/bash-completion/rfpkg.bash
+++ b/conf/bash-completion/rfpkg.bash
@@ -33,7 +33,7 @@ _rfpkg()
     # global options
 
     local options="--help -v -q"
-    local options_value="--dist --release --user --path"
+    local options_value="--release --user --path"
     local commands="build chain-build ci clean clog clone co commit compile \
     container-build diff gimmespec giturl help gitbuildhash import install lint \
     local mockbuild mock-config new new-sources patch prep pull push retire \
@@ -72,7 +72,7 @@ _rfpkg()
         fi
 
         case "$prev" in
-            --dist|--release)
+            --release)
                 ;;
             --user|-u)
                 ;;


### PR DESCRIPTION
`--dist` is being removed from `rpkg` because it is deprecated. So, its instance should be removed from `rfpkg` as well.

Related PR: [rpkg](https://pagure.io/rpkg/pull-request/556)

